### PR TITLE
add includes, remove unnecessary assert

### DIFF
--- a/clutchlog/clutchlog.h
+++ b/clutchlog/clutchlog.h
@@ -13,6 +13,7 @@
     namespace fs = std::filesystem;
 #endif
 
+#include <iterator>
 #include <iostream>
 #include <sstream>
 #include <fstream>

--- a/clutchlog/clutchlog.h
+++ b/clutchlog/clutchlog.h
@@ -1296,7 +1296,6 @@ class clutchlog
             row = replace(row, "\\{msg\\}", what);
 
             const std::filesystem::path filepath(file);
-            assert(filepath.is_absolute());
             std::string filename;
             std::filesystem::path::iterator ip = filepath.end();
             std::advance(ip, -2);

--- a/tests/t-assert.cpp
+++ b/tests/t-assert.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <cassert>
+#include <cstring>
 
 #include "../clutchlog/clutchlog.h"
 


### PR DESCRIPTION
Add missing `#include`s in a test and library itself (didn't compile for me without those).

Remove `assert(filepath.is_absolute());`, as it caused assertion failure for non absolute filenames; I'm not entirely sure why `__FILE__` is sometimes absolute and sometimes it isn't, but after removing the assert logging seems usable in both cases, example output with non-absolute path `__FILE__`:
```
[test2] I:> testing ............................................................................................................. main @ test2.cpp:18
```
I guess filtering might be affected with short filenames?